### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+ExplicitImports = "1.14"
 ProgressMeter = "1.2"
 PyCall = "1.90"
 Requires = "0.5, 1.0"
@@ -17,8 +18,9 @@ SpecialFunctions = "0.8, 0.9, 1.2, 2"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OrdinaryDiffEq"]
+test = ["ExplicitImports", "Test", "OrdinaryDiffEq"]

--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -3,8 +3,6 @@
 #http://fenics.readthedocs.io/projects/UFL/en/latest/api-doc/Expression.html
 #Tests for these can be found in the test_jfem.jl file.
 
-using FEniCS
-
 @fenicsclass FunctionSpace
 
 #Use Functionspace for scalar fields

--- a/src/jplot.jl
+++ b/src/jplot.jl
@@ -1,7 +1,6 @@
 #this file contains function related to plotting the mesh objects.
 #we will use matplotlib.pyplot to achieve this
 #
-using FEniCS
 
 import PyPlot: triplot, plot_trisurf, tripcolor, tricontourf
 

--- a/src/jsolve.jl
+++ b/src/jsolve.jl
@@ -1,6 +1,5 @@
 #this file contains functions/wrappers related to the solve function in FEniCS
 #https://fenicsproject.org/olddocs/dolfin/1.3.0/python/programmers-reference/fem/solving/solve.html
-using FEniCS
 
 function solve(A::Matrix, x, b::Matrix, solvers...)
     fenics.solve(A.pyobject, x, b.pyobject, solvers...)

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using FEniCS
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(FEniCS) === nothing
+    @test check_no_stale_explicit_imports(FEniCS) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 
 FEniCS.set_log_level(FEniCS.WARNING)
 
+@testset "Explicit Imports" begin
+    include("explicit_imports.jl")
+end
+
 examples_dir = joinpath(@__DIR__, "..", "examples")
 @assert ispath(examples_dir)
 example_filenames = readdir(examples_dir)


### PR DESCRIPTION
## Summary

- Remove circular `using FEniCS` from included files (jfem.jl, jsolve.jl, jplot.jl) - these files are included within the FEniCS module, so importing the module from within itself is unnecessary
- Add ExplicitImports.jl tests to CI to prevent import hygiene regression
- Add ExplicitImports as a test-only dependency in Project.toml

## Files Changed

- `src/jfem.jl` - Removed `using FEniCS`
- `src/jsolve.jl` - Removed `using FEniCS`
- `src/jplot.jl` - Removed `using FEniCS`
- `Project.toml` - Added ExplicitImports as test-only dependency with compat
- `test/explicit_imports.jl` - New file with ExplicitImports tests
- `test/runtests.jl` - Added Explicit Imports testset

## Test plan

- [ ] CI passes with the FEniCS Docker container
- [ ] ExplicitImports tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)