### PR TITLE
Bump compat for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,9 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+ADTypes = "1"
 ExplicitImports = "1"
+OrdinaryDiffEq = "6, 7"
 ProgressMeter = "1.2"
 PyCall = "1.90"
 Requires = "0.5, 1.0"
@@ -18,9 +20,10 @@ SpecialFunctions = "0.8, 0.9, 1.2, 2"
 julia = "1.6"
 
 [extras]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Test", "OrdinaryDiffEq"]
+test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq"]

--- a/examples/heat_equation.jl
+++ b/examples/heat_equation.jl
@@ -10,6 +10,7 @@ module HeatEquationExample
 
 using Test
 using OrdinaryDiffEq
+using ADTypes: AutoFiniteDiff
 using FEniCS
 
 mesh = UnitIntervalMesh(50)
@@ -40,11 +41,11 @@ prob = ODEProblem(f!, u0_vec, tspan, p)
 u_true = interpolate(Expression(u_str, degree = 2, pi = Float64(pi), t = tspan[2]), V)
 
 # some algorithms to try:
-# alg = ImplicitEuler(autodiff=false)
-# alg = Rosenbrock23(autodiff=false)
-# alg = Rodas5(autodiff=false)
+# alg = ImplicitEuler(autodiff=AutoFiniteDiff())
+# alg = Rosenbrock23(autodiff=AutoFiniteDiff())
+# alg = Rodas5(autodiff=AutoFiniteDiff())
 
-alg = KenCarp4(autodiff = false)
+alg = KenCarp4(autodiff = AutoFiniteDiff())
 sol = OrdinaryDiffEq.solve(prob, alg, reltol = 1.0e-6, abstol = 1.0e-6)
 
 vec_sol = get_array(p.u)


### PR DESCRIPTION
## Summary

Bumps compat bounds and migrates code for OrdinaryDiffEq v7 / SciMLBase v3 ecosystem (SciML/OrdinaryDiffEq.jl#3562, SciML/OrdinaryDiffEq.jl#3565).

### Changes

- **`Project.toml`**: Add `OrdinaryDiffEq = "6, 7"` compat entry (was missing entirely). Add `ADTypes = "1"` as a test dependency (needed by the heat equation example under OrdinaryDiffEq v7).
- **`examples/heat_equation.jl`**: Migrate `autodiff = false` → `autodiff = AutoFiniteDiff()` throughout. In OrdinaryDiffEq v7 the `autodiff` keyword no longer accepts a `Bool`; it must receive an `ADTypes.AbstractADType` object. See [NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md#autodiff-bool-no-longer-accepted).

### Breaking change referenced

From OrdinaryDiffEq v7 NEWS.md:

> `autodiff::Bool` forced a runtime branch between AD backends that the compiler couldn't specialize through; `autodiff::AbstractADType` dispatches at compile time.

```julia
# v6
KenCarp4(autodiff=false)   # worked

# v7 — must use ADTypes
KenCarp4(autodiff=AutoFiniteDiff())
```

### No other breaking patterns found

Searched `src/`, `test/`, and `examples/` for all other v7 breaking patterns (`u_modified!`, `sol.destats`, `DEAlgorithm`, `sol.retcode == :Symbol`, `sol[i]` indexing, controller kwargs, `constructXxx` tableau functions). None are used in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)