### PR TITLE
Fix OrdinaryDiffEq 7 solver re-export breakage (import KenCarp4 from OrdinaryDiffEqSDIRK)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 ADTypes = "1"
 ExplicitImports = "1"
 OrdinaryDiffEq = "6, 7"
+OrdinaryDiffEqSDIRK = "1, 2"
 ProgressMeter = "1.2"
 PyCall = "1.90"
 Requires = "0.5, 1.0"
@@ -23,7 +24,8 @@ julia = "1.6"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq"]
+test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqSDIRK"]

--- a/examples/heat_equation.jl
+++ b/examples/heat_equation.jl
@@ -10,6 +10,7 @@ module HeatEquationExample
 
 using Test
 using OrdinaryDiffEq
+using OrdinaryDiffEqSDIRK: KenCarp4
 using ADTypes: AutoFiniteDiff
 using FEniCS
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

OrdinaryDiffEq 7.0.0 intentionally dropped its blanket solver re-exports to cut TTFS (dependency count 30 → 6; documented in ODE's `NEWS.md`). The documented downstream migration is to import non-default solvers from their sub-packages.

`KenCarp4` moved to `OrdinaryDiffEqSDIRK` and is no longer exported by `using OrdinaryDiffEq`. `examples/heat_equation.jl` (run by `test/runtests.jl`) uses a bare `KenCarp4`, so under ODE 7 it fails with:

```
UndefVarError: `KenCarp4` not defined
```

## Fix

- `examples/heat_equation.jl`: add `using OrdinaryDiffEqSDIRK: KenCarp4` alongside the existing `using OrdinaryDiffEq`.
- `Project.toml`: add `OrdinaryDiffEqSDIRK` to `[extras]`, the `test` target, and `[compat]` (`"1, 2"`, which keeps the existing `OrdinaryDiffEq = "6, 7"` downgrade space intact — SDIRK 1.x pairs with the ODE 6 sub-package ecosystem, 2.x with ODE 7).

`Tsit5`, `Rosenbrock23`, `ODEProblem`, `solve`, `ReturnCode`, etc. are still exported by ODE 7, so no other example needed changing. The `solve(...)` calls in the other tutorials are FEniCS's own `solve`, not the ODE solver.

## Verification

Reproduced and verified the solver path in an isolated depot on Julia 1.10 with **OrdinaryDiffEq 7.0.0**:

- **Before:** `using OrdinaryDiffEq; KenCarp4` → `UndefVarError: KenCarp4 not defined`.
- **After:** `using OrdinaryDiffEqSDIRK: KenCarp4` resolves; `KenCarp4(autodiff = AutoFiniteDiff())` constructs and `OrdinaryDiffEq.solve(prob, alg, reltol=1e-6, abstol=1e-6)` returns `ReturnCode.Success` (decay test `e^{-0.1} ≈ 0.90484` matches).
- The exact edited import block from `heat_equation.jl` (`using Test` / `using OrdinaryDiffEq` / `using OrdinaryDiffEqSDIRK: KenCarp4` / `using ADTypes: AutoFiniteDiff`) loads cleanly and the KenCarp4 solve path passes.
- Test-environment deps co-resolve: `OrdinaryDiffEq = 7.0.0`, `OrdinaryDiffEqSDIRK = 2.7.0`, `ADTypes = 1.22.0`, `ExplicitImports`.

**CI caveat:** FEniCS.jl wraps Python FEniCS through PyCall and `using FEniCS` requires the `cmhyett/julia-fenics` container, which is not available in this local environment. The full `Pkg.test` (which loads FEniCS and runs the meshing/solve body of the example) was therefore **not** run locally — only the OrdinaryDiffEq import/solve path that this change affects was verified. The remaining body of `heat_equation.jl` is unchanged and exercises FEniCS, which is what CI's container provides.

Runic v1.7.0 check passes on the edited `.jl` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)