### PR TITLE
Canonicalize tests to @safetestset for per-unit module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ OrdinaryDiffEqSDIRK = "1, 2"
 ProgressMeter = "1.2"
 PyCall = "1.90"
 Requires = "0.5, 1.0"
+SafeTestsets = "0.1, 1"
 SpecialFunctions = "0.8, 0.9, 1.2, 2"
 julia = "1.6"
 
@@ -25,7 +26,8 @@ ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqSDIRK"]
+test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqSDIRK", "SafeTestsets"]

--- a/test/assign_tests.jl
+++ b/test/assign_tests.jl
@@ -1,0 +1,14 @@
+using FEniCS
+using Test
+
+@testset "assign" begin
+    mesh = UnitIntervalMesh(10)
+    V = FunctionSpace(mesh, "P", 1)
+    u = interpolate(Expression("x[0]", degree = 1), V)
+    arr1 = get_array(u)
+    arr2 = randn(size(arr1))
+    assign(u, arr2)
+    @test get_array(u) == arr2
+    assign(u, arr1)
+    @test get_array(u) == arr1
+end

--- a/test/creation_tests.jl
+++ b/test/creation_tests.jl
@@ -1,0 +1,6 @@
+using FEniCS
+using Test
+
+@test include("test_create.jl")
+@test include("test_pycreate.jl")
+@test include("test_jfem.jl")

--- a/test/examples_tests.jl
+++ b/test/examples_tests.jl
@@ -1,0 +1,19 @@
+using FEniCS
+using Test
+
+FEniCS.set_log_level(FEniCS.WARNING)
+
+examples_dir = joinpath(@__DIR__, "..", "examples")
+@assert ispath(examples_dir)
+example_filenames = readdir(examples_dir)
+@assert "tutorial1.jl" in example_filenames
+
+@testset "Example $(filename)" for filename in example_filenames
+    path = joinpath(examples_dir, filename)
+    @test (include(path); true)
+    # Test that PyCall is not used in the example.
+    # Use of PyCall indicates, that we did not wrap enough
+    # functionality
+    s = read(path, String)
+    @test !occursin("PyCall", s)
+end

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -1,0 +1,14 @@
+using FEniCS
+using Test
+
+#tests relating to interface.jl file
+@testset "Interface" begin
+    global mesh = UnitSquareMesh(2, 2)
+    dbc(x, y) = 1
+    global u = feMesh(mesh, dbc)
+    @test (u.n_nodes == 9)
+    @test (u.n_elements == 8)
+    @test (u.n_internal_nodes == 1)
+    @test (u.n_boundary_nodes == 8)
+    @test (u.node_vals == [1, 1, 1, 1, 0, 1, 1, 1, 1])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,53 +1,21 @@
-using FEniCS
-using Test
+using SafeTestsets
 
-FEniCS.set_log_level(FEniCS.WARNING)
-
-@testset "Explicit Imports" begin
+@safetestset "Explicit Imports" begin
     include("explicit_imports.jl")
 end
 
-examples_dir = joinpath(@__DIR__, "..", "examples")
-@assert ispath(examples_dir)
-example_filenames = readdir(examples_dir)
-@assert "tutorial1.jl" in example_filenames
-
-@testset "Example $(filename)" for filename in example_filenames
-    path = joinpath(examples_dir, filename)
-    @test (include(path); true)
-    # Test that PyCall is not used in the example.
-    # Use of PyCall indicates, that we did not wrap enough
-    # functionality
-    s = read(path, String)
-    @test !occursin("PyCall", s)
+@safetestset "Examples" begin
+    include("examples_tests.jl")
 end
 
-@testset "Creation" begin
-    @test include("test_create.jl")
-    @test include("test_pycreate.jl")
-    @test include("test_jfem.jl")
-end;
-
-@testset "assign" begin
-    mesh = UnitIntervalMesh(10)
-    V = FunctionSpace(mesh, "P", 1)
-    u = interpolate(Expression("x[0]", degree = 1), V)
-    arr1 = get_array(u)
-    arr2 = randn(size(arr1))
-    assign(u, arr2)
-    @test get_array(u) == arr2
-    assign(u, arr1)
-    @test get_array(u) == arr1
+@safetestset "Creation" begin
+    include("creation_tests.jl")
 end
 
-#tests relating to interface.jl file
-@testset "Interface" begin
-    global mesh = UnitSquareMesh(2, 2)
-    dbc(x, y) = 1
-    global u = feMesh(mesh, dbc)
-    @test (u.n_nodes == 9)
-    @test (u.n_elements == 8)
-    @test (u.n_internal_nodes == 1)
-    @test (u.n_boundary_nodes == 8)
-    @test (u.node_vals == [1, 1, 1, 1, 0, 1, 1, 1, 1])
-end;
+@safetestset "assign" begin
+    include("assign_tests.jl")
+end
+
+@safetestset "Interface" begin
+    include("interface_tests.jl")
+end


### PR DESCRIPTION
## What

Converts the independent top-level test units in `test/runtests.jl` from plain `@testset` to `@safetestset`, so each unit runs in its own freshly generated module. This matches the canonical OrdinaryDiffEq test structure (isolation between tests + world-age safety).

## How

Each unit body is extracted into its own self-contained file and invoked as `@safetestset "X" begin include("x.jl") end`:

| Unit | File |
|------|------|
| Explicit Imports | `explicit_imports.jl` (already self-contained upstream) |
| Examples | `examples_tests.jl` (`set_log_level` + parametrized example loop) |
| Creation | `creation_tests.jl` (includes `test_create`/`test_pycreate`/`test_jfem`) |
| assign | `assign_tests.jl` |
| Interface | `interface_tests.jl` |

- Each new extracted file carries its own `using FEniCS` / `using Test`.
- The `include()` form (not an inline `@safetestset` body) is used so imports run before any FEniCS symbols are resolved, and include paths resolve relative to `test/` as before.
- The parametrized example loop and other inner `@testset`s stay plain `@testset` — the unit-level `@safetestset` already isolates them.
- `SafeTestsets` added to test deps (`[extras]` + `[targets].test`, `[compat]` `SafeTestsets = "0.1, 1"`).

Same units run in the same order with the same assertions; only the isolation mechanism changed.

## Verification

FEniCS requires the FEniCS Python stack (CI runs in the `cmhyett/julia-fenics` container), which isn't available for a local run here. Verified **statically**: `Meta.parseall` is clean on all test files, each `@safetestset` carries its needed imports, the `@safetestset "X" begin include(...) end` shape was smoke-tested against SafeTestsets, and the files pass Runic `--check`. **CI will run the actual suite.**

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)