### PR TITLE
Fix QA group dispatch: pass QA via the `qa` kwarg, not `groups`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "1.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -12,9 +11,9 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 ADTypes = "1"
 ExplicitImports = "1"
+LinearAlgebra = "1"
 OrdinaryDiffEq = "6, 7"
 OrdinaryDiffEqSDIRK = "1, 2"
-ProgressMeter = "1.2"
 PyCall = "1.90"
 Requires = "0.5, 1.0"
 SafeTestsets = "0.1, 1"

--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -38,7 +38,7 @@ function __init__()
 end
 #the below code is an adaptation of aleadev.FEniCS.jl
 import Base: size, length, show, *, +, -, /, ^, sin, cos, tan, asin, acos, atan, exp, log,
-    repr, div, sqrt, split
+    repr, div, sqrt, split, write
 
 import SpecialFunctions: besseli, besselj, besselk, bessely
 export besseli, besselj, besselk, bessely

--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -21,9 +21,6 @@ const mshr = PyCall.PyNULL()
 
 function __init__()
     @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" include("jplot.jl")
-    @require ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca" begin
-        using ProgressMeter
-    end
     copy!(fenics, pyimport_conda("fenics", "fenics=2019.1.0", "conda-forge"))
     copy!(ufl, pyimport_conda("ufl", "ufl=2019.1.0", "conda-forge"))
     include_mshr && copy!(mshr, pyimport_conda("mshr", "mshr=2019.1.0", "conda-forge"))
@@ -41,7 +38,7 @@ function __init__()
 end
 #the below code is an adaptation of aleadev.FEniCS.jl
 import Base: size, length, show, *, +, -, /, ^, sin, cos, tan, asin, acos, atan, exp, log,
-    repr, div, sqrt, split, write
+    repr, div, sqrt, split
 
 import SpecialFunctions: besseli, besselj, besselk, bessely
 export besseli, besselj, besselk, bessely
@@ -68,7 +65,7 @@ macro fenicsclass(name::Symbol, base1::Symbol = :fenicsobject)
         end
     )
 end
-export fenicsclass
+export @fenicsclass
 
 @enum LOGLEVEL begin
     CRITICAL = 50

--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -17,7 +17,7 @@ end
 export FunctionSpace, VectorFunctionSpace
 
 @fenicsclass Expression
-function Argument(V, number, part::StringOrSymbol = nothing)
+function Argument(V, number, part::Union{StringOrSymbol, Nothing} = nothing)
     return Expression(fenics.Argument(V.pyobject, number, part = part))
 end
 TrialFunction(V::FunctionSpace) = Expression(fenics.TrialFunction(V.pyobject))

--- a/src/jsolve.jl
+++ b/src/jsolve.jl
@@ -142,11 +142,16 @@ TimeSeries(path::StringOrSymbol) = fenics.TimeSeries(path)
 retrieve(timeseries, placeholder, time) = timeseries.retrieve(placeholder, time)
 export TimeSeries, retrieve
 
-write(path, solution, time::Number) = path.write(solution.pyobject, time)
-write(path, solution::PyObject, time::Number) = path.write(solution, time)
+# `write` extends `Base.write`. Typing `solution::fenicsobject` keeps this from
+# being type piracy (a FEniCS-owned argument), and typing `path::PyObject` (the
+# value returned by `XDMFFile`/`TimeSeries`) keeps it from being ambiguous with
+# `Base.write(::IO, ...)` / `write(::AbstractString, ...)`. A raw-`PyObject`
+# solution is unused; use `store` (a FEniCS-owned function) for raw vectors such
+# as `vector(u)`.
+write(path::PyObject, solution::fenicsobject, time::Number) = path.write(solution.pyobject, time)
 
-store(path, solution, time::Number) = path.store(solution.pyobject, time)
-store(path, solution::PyObject, time::Number) = path.store(solution, time)
+store(path::PyObject, solution, time::Number) = path.store(solution.pyobject, time)
+store(path::PyObject, solution::PyObject, time::Number) = path.store(solution, time)
 
 export write, store
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,11 +5,9 @@ run_tests(;
     # body (core.jl) rather than as independent per-file groups, so it is passed
     # explicitly instead of being discovered as a folder.
     core = joinpath(@__DIR__, "core.jl"),
-    groups = Dict(
-        "QA" => (;
-            env = joinpath(@__DIR__, "qa"),
-            body = joinpath(@__DIR__, "qa", "qa.jl"),
-        ),
+    qa = (;
+        env = joinpath(@__DIR__, "qa"),
+        body = joinpath(@__DIR__, "qa", "qa.jl"),
     ),
     # The original ran only the Core body for the default GROUP="All"; QA ran only
     # when explicitly selected (it exited early before loading FEniCS).


### PR DESCRIPTION
## Problem

The QA CI job fails on `master` (introduced by the canonicalization conversion #154) before any test runs:

```
ERROR: LoadError: ArgumentError: run_tests: GROUP="QA" was requested but no `qa` body was provided
   @ SciMLTesting .../SciMLTesting.jl:959
   @ test/runtests.jl:3
```

The conversion placed the QA group inside the `groups` Dict. But `SciMLTesting.run_tests` routes `GROUP="QA"` through a dedicated `elseif group == "QA"` branch that consumes the `qa` keyword argument and short-circuits **before** the `groups` table is ever consulted. With `qa` left unset, that branch throws "no `qa` body was provided" — so a QA entry in `groups` is unreachable for `GROUP="QA"`.

## Fix

Move the QA spec from the `groups` Dict to the dedicated `qa` keyword argument (the documented SciMLTesting form). `all = ["Core"]` is retained, so QA still runs **only** when `GROUP="QA"` is explicitly selected and remains excluded from the default `GROUP="All"` / local `]test` run, exactly as before.

## Verification (local, Julia 1.10 + SciMLTesting v1.2.0)

Reproduced the exact CI error with the old `groups["QA"]` form, then confirmed the fix with a stub tree mirroring `test/` (core.jl + qa/qa.jl + qa/Project.toml):

- `GROUP=QA` → **exit 0**, QA body runs (was: `ArgumentError: no qa body provided`)
- `GROUP=Core` → exit 0, Core only
- `GROUP=All` / no GROUP → exit 0, Core only (QA excluded)

In a checkout of this repo, `GROUP=QA julia test/runtests.jl` now reaches the QA branch, activates `test/qa`, develops local FEniCS, and resolves Aqua/JET/PyCall — it no longer throws the dispatch error (the local run then needs the `cmhyett/julia-fenics` Python stack, which is only present in CI).

Note: the other three master jobs (Core julia 1, Core julia pre, QA julia lts) failed separately with `permission denied ... docker.sock` — transient self-hosted-runner infrastructure errors unrelated to this change; not addressed here.

Please ignore until reviewed by @ChrisRackauckas.



---

## Follow-up: fix the QA package-quality failures the QA group now surfaces (commits 85a709b, f70877a)

With the dispatch fixed, the QA group runs FEniCS's own `Aqua.test_all`/`JET.report_package` for the first time, exposing six pre-existing package-quality issues (all present on `master`, none introduced here). Each is fixed at its real cause; **no Aqua check is disabled or loosened**:

| QA check | Finding | Fix |
|---|---|---|
| **Piracy** | `write(path, solution, time::Number)` (jsolve.jl) extended `Base.write` with no FEniCS-owned argument type. | Keep extending `Base.write` (so `write` stays a single function usable unqualified), but type `solution::fenicsobject` so the method is FEniCS-owned, not piracy. The unused, unavoidably-piratical `write(::Any, ::PyObject, ::Number)` overload is dropped (use `store` for raw vectors). |
| **Method ambiguity** | The `write` method's untyped `path` clashed with `Base.write(::IO, ...)` and `write(::AbstractString, ...)`. | Type `path::PyObject` (what `XDMFFile`/`TimeSeries` return), disjoint from `IO`/`AbstractString`. |
| **Undefined exports** | `export fenicsclass` named a binding that doesn't exist — the macro is `@fenicsclass`. | `export @fenicsclass`. |
| **JET** (1 report) | `Argument(V, number)` → `Argument(::Any, ::Any, ::Nothing)` no matching method, because `part::StringOrSymbol` cannot hold its own `nothing` default. | Widen to `part::Union{StringOrSymbol, Nothing} = nothing` (PyCall maps `nothing`→`None`, matching `fenics.Argument(part=None)`). |
| **Stale dependencies** | `ProgressMeter` declared but unused (only a no-op `@require ... using ProgressMeter`; no function from it is ever called). | Remove from `[deps]`, `[compat]`, and the dead `__init__` block. |
| **deps_compat** | `LinearAlgebra` (runtime stdlib dep) had no `[compat]` entry. | Add `LinearAlgebra = "1"`. |

The first attempt (85a709b) instead removed `write` from the `Base` import, which made `FEniCS.write` clash with the exported `Base.write` and broke the Core examples (`UndefVarError: write` in tutorial8/9). f70877a corrects that by extending `Base.write` and disambiguating via argument types as above.

**Verified locally** in the `cmhyett/julia-fenics` container (the fenics Python stack) with Julia 1.10: `Aqua.test_all(FEniCS)` → 11 passed / 0 failed; `JET.test_package(FEniCS)` → 1 passed / 0 failed; and a `module … using FEniCS; write(…)` sanity check confirms the Base.write name clash is gone. (The earlier CI on 85a709b had already shown both QA legs green — i.e. piracy/exports/stale/deps_compat/JET all fixed — and Core red from the clash; f70877a keeps QA green and unbreaks Core.)

Please ignore until reviewed by @ChrisRackauckas.
