### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ADTypes = "1"
-ExplicitImports = "1"
 LinearAlgebra = "1"
 OrdinaryDiffEq = "6, 7"
 OrdinaryDiffEqSDIRK = "1, 2"
@@ -24,7 +23,6 @@ julia = "1.10"
 
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -32,4 +30,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "ExplicitImports", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqSDIRK", "SafeTestsets", "SciMLTesting"]
+test = ["ADTypes", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqSDIRK", "SafeTestsets", "SciMLTesting"]

--- a/test/core.jl
+++ b/test/core.jl
@@ -3,10 +3,6 @@ using Test
 
 FEniCS.set_log_level(FEniCS.WARNING)
 
-@testset "Explicit Imports" begin
-    include("explicit_imports.jl")
-end
-
 examples_dir = joinpath(@__DIR__, "..", "examples")
 @assert ispath(examples_dir)
 example_filenames = readdir(examples_dir)

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using FEniCS
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(FEniCS) === nothing
-    @test check_no_stale_explicit_imports(FEniCS) === nothing
-end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ FEniCS = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,14 @@
-using FEniCS, Aqua, JET, Test
+using SciMLTesting, FEniCS, Test
+using JET
 
-@testset "Aqua" begin
-    Aqua.test_all(FEniCS)
-end
-
-@testset "JET" begin
-    JET.test_package(FEniCS; target_defined_modules = true)
-end
+run_qa(
+    FEniCS;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # `getdoc` is not public in `Base.Docs`, but FEniCS extends
+        # `Base.Docs.getdoc(::fenicsobject)` (src/FEniCS.jl) to surface the wrapped
+        # PyObject's docstring. Extending a Base-internal method legitimately
+        # requires naming it; nothing to make public here.
+        all_qualified_accesses_are_public = (; ignore = (:getdoc,)),
+    ),
+)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled (mode: hand-rolled → `run_qa`).

## `test/qa/qa.jl`

Before: hand-rolled `Aqua.test_all(FEniCS)` + `JET.test_package(FEniCS; target_defined_modules = true)`.

After:
```julia
using SciMLTesting, FEniCS, Test
using JET

run_qa(
    FEniCS;
    explicit_imports = true,
    ei_kwargs = (; all_qualified_accesses_are_public = (; ignore = (:getdoc,))),
)
```

Aqua + ExplicitImports come from SciMLTesting's own deps; `using JET` triggers the JET weakdep extension so the JET check still runs.

## ExplicitImports findings (enabled here for the first time at the run_qa level)

Ran all six EI checks against released SciMLTesting 1.6.0:

| Check | Result |
|---|---|
| `no_implicit_imports` | pass |
| `no_stale_explicit_imports` | pass |
| `all_explicit_imports_via_owners` | pass |
| `all_qualified_accesses_via_owners` | pass |
| `all_qualified_accesses_are_public` | **fail → ignored** (see below) |
| `all_explicit_imports_are_public` | pass |

The single finding is `getdoc`, which is not public in `Base.Docs`. FEniCS extends `Base.Docs.getdoc(::fenicsobject)` (`src/FEniCS.jl:85`) to surface a wrapped PyObject's docstring. Extending a Base-internal method requires naming it and there is nothing to make public, so it is **ignored** (not skipped) via `ei_kwargs`, documented with its source module. No `aqua_broken`/`jet_broken`/`ei_broken` markers are needed — Aqua (`test_all`, 11/11) and JET (0 reports) are clean.

## Other changes

- The standalone `test/explicit_imports.jl` (run in the Core group via `core.jl`) only ran two of the six checks; `run_qa` runs all six, so that include + the file are removed, and `ExplicitImports` drops from the root `[extras]`/`[targets].test` (now supplied transitively in the QA env via SciMLTesting).
- `test/qa/Project.toml`: SciMLTesting compat → `"1.6"`; drop ExplicitImports (transitive via SciMLTesting); keep Aqua (`test_all`'s ambiguities sub-check), JET, and SafeTestsets (`run_tests` wraps each group body in `@safetestset`).

## Verification

Run locally against **released SciMLTesting 1.6.0** (resolved from the registry, no dev-from-branch) inside the CI `cmhyett/julia-fenics` container so `using FEniCS` (PyCall → conda `fenics`) succeeds, on Julia 1.10.11:

```
Test Summary: | Pass  Total     Time
QA            |   18     18  1m36.3s
```

18 = 11 Aqua + 1 JET + 6 ExplicitImports. 0 Fail / 0 Error / 0 Broken. A control run without the `getdoc` ignore errors on exactly `getdoc`, confirming the ignore is load-bearing and the check genuinely runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)