### PR TITLE
Add Downgrade CI lane (containerized Core downgrade)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,19 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "Core"
+      container: "cmhyett/julia-fenics:latest"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

FEniCS.jl had **no Downgrade CI lane** (audit: "wrapper; missing downgrade — confirm intentional or add a minimal one"). It's a PyCall wrapper around the Python FEniCS/DOLFIN FEM stack, so it *looks* exempt — but it still has real registry Julia dependencies with compat floors (`PyCall`, `SpecialFunctions`, `ADTypes`, `OrdinaryDiffEq`, `OrdinaryDiffEqSDIRK`, `SciMLTesting`). A downgrade lane is therefore meaningful, and the centralized reusable `downgrade.yml` supports a `container:` input precisely for Python-stack packages — the same container (`cmhyett/julia-fenics:latest`) the existing `CI.yml` already uses. So this is not a legitimate skip; it's a genuinely missing lane that can be added.

This PR adds `.github/workflows/Downgrade.yml` routed through `SciML/.github/.github/workflows/downgrade.yml@v1` with `group: Core` and `container: cmhyett/julia-fenics:latest`.

## Validation (local, inside the real container)

Ran the centralized-workflow steps by hand inside `cmhyett/julia-fenics:latest` at Julia 1.10 (lts, the downgrade default), using `julia-actions/julia-downgrade-compat` v2.6.1 in `deps` mode:

- `downgrade.jl` resolved minimal versions cleanly — PyCall 1.96.0, SpecialFunctions 1.6.1, Requires 1.0.0, ADTypes 1.7.1, OrdinaryDiffEq 6.80.0, OrdinaryDiffEqSDIRK 1.1.0, SciMLTesting 1.0.0.
- `Pkg.build` (PyCall linked to the container's `/usr/bin/python3` FEniCS) succeeded.
- `GROUP=Core Pkg.test` at floors: **Core 35/35 pass** (2m52s; the FEM examples JIT-compile and run against the real DOLFIN runtime).

No source or compat-floor changes were needed — the existing floors are already downgrade-clean; the lane was simply absent.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)