### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FEniCS"
 uuid = "186dfeec-b415-5c13-8e76-5fbf19f56f9b"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Automated patch version bump (1.2.0 -> 1.2.1) to release unreleased commits on `master` via JuliaRegistrator.