### PR TITLE
Remove FEniCS QA API docs override

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,22 +4,6 @@ using JET
 run_qa(
     FEniCS;
     explicit_imports = true,
-    api_docs_kwargs = (;
-        rendered = true,
-        rendered_ignore = (
-            :besseli,
-            :besselj,
-            :besselk,
-            :bessely,
-            :div,
-            :norm,
-            :repr,
-            :size,
-            :split,
-            :sqrt,
-            :write,
-        ),
-    ),
     ei_kwargs = (;
         # `getdoc` is not public in `Base.Docs`, but FEniCS extends
         # `Base.Docs.getdoc(::fenicsobject)` (src/FEniCS.jl) to surface the wrapped


### PR DESCRIPTION
## Summary
- removes the repository-specific `api_docs_kwargs` override from the SciMLTesting QA invocation
- retains the unrelated explicit-import exception for the documented Base extension

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `Runic.main(["--check", "--docstrings", "."])` with Runic.jl 1.7.0

Ignore until reviewed by @ChrisRackauckas.
