### PR TITLE
Require SpecialFunctions 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ PyCall = "1.90"
 Requires = "1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.1"
-SpecialFunctions = "0.8, 0.9, 1.2, 2"
+SpecialFunctions = "2"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary

Ignore this PR until it has been reviewed by @ChrisRackauckas.

- require SpecialFunctions 2
- retire the 0.8, 0.9, and 1.x compatibility lines, all superseded by the stable 2.x series since 2021

FEniCS imports and re-exports the four Bessel functions from SpecialFunctions.
This is intentionally a focused one-line compat change, validated in the same
FEniCS container used by CI. It is based on the merged downgrade-floor fix in
#163.

## Process

- resolved the deployed Julia 1.10 downgrade graph and locked its manifest
- ran Core against that locked graph without re-resolving
- ran current Core and QA on Julia 1.12 in `cmhyett/julia-fenics:latest`
- rebased onto the merged #163 foundation and repeated both exact-floor and
  current Core validation
- ran the repository-wide Runic check and `git diff --check`

## Local validation

- Exact downgrade resolution on Julia 1.10: selected SpecialFunctions 2.0.0.
- Locked exact-floor `GROUP=Core` on Julia 1.10 in
  `cmhyett/julia-fenics:latest`: **35 passed**.
- Current-resolution `GROUP=Core` on Julia 1.12 in the same container:
  **35 passed**.
- Current-resolution `GROUP=QA` on Julia 1.12 in the same container:
  **20 passed**.
- Post-rebase locked exact-floor Core: **35 passed**.
- Post-rebase current-resolution Core: **35 passed**.
- Runic 1.7 repository check: **30 passed**.
- `git diff --check`: passed.
