### PR TITLE
Load without a Python FEniCS install (warn loudly instead of failing import)

### DIFF
--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -27,20 +27,29 @@ const mshr = PyCall.PyNULL()
 
 function __init__()
     @require PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee" include("jplot.jl")
-    copy!(fenics, pyimport_conda("fenics", "fenics=2019.1.0", "conda-forge"))
-    copy!(ufl, pyimport_conda("ufl", "ufl=2019.1.0", "conda-forge"))
-    include_mshr && copy!(mshr, pyimport_conda("mshr", "mshr=2019.1.0", "conda-forge"))
+    try
+        copy!(fenics, pyimport_conda("fenics", "fenics=2019.1.0", "conda-forge"))
+        copy!(ufl, pyimport_conda("ufl", "ufl=2019.1.0", "conda-forge"))
+        include_mshr && copy!(mshr, pyimport_conda("mshr", "mshr=2019.1.0", "conda-forge"))
 
-    # initialize constants at loadtime
-    global dx = Measure(fenics.dx)
-    global ds = Measure(fenics.ds)
-    global dS = Measure(fenics.dS)
-    global dP = Measure(fenics.dP)
-    global tetrahedron = fenics.tetrahedron
-    global hexahedron = fenics.hexahedron #matplotlib cannot handle hexahedron elements
-    global triangle = fenics.triangle
-    global quadrilateral = fenics.quadrilateral
-    return copy!(CellType.pyobject, fenics.CellType)
+        # initialize constants at loadtime
+        global dx = Measure(fenics.dx)
+        global ds = Measure(fenics.ds)
+        global dS = Measure(fenics.dS)
+        global dP = Measure(fenics.dP)
+        global tetrahedron = fenics.tetrahedron
+        global hexahedron = fenics.hexahedron #matplotlib cannot handle hexahedron elements
+        global triangle = fenics.triangle
+        global quadrilateral = fenics.quadrilateral
+        copy!(CellType.pyobject, fenics.CellType)
+    catch err
+        @warn """
+        FEniCS.jl loaded but could not import the Python FEniCS/DOLFIN installation, so \
+        it is not usable. Calls into FEniCS will error until the `fenics` and `ufl` \
+        Python packages (FEniCS 2019.1.0) are installed and importable through PyCall.jl.
+        """ exception = (err, catch_backtrace())
+    end
+    return nothing
 end
 #the below code is an adaptation of aleadev.FEniCS.jl
 import Base: size, length, show, *, +, -, /, ^, sin, cos, tan, asin, acos, atan, exp, log,


### PR DESCRIPTION
Makes FEniCS.jl importable even when the Python FEniCS/DOLFIN installation is missing, unblocking registration.

## Problem
`__init__` called `pyimport_conda("fenics", ...)` / `pyimport_conda("ufl", ...)` unconditionally and initialized global constants from them. When the Python side is absent (as in the General AutoMerge sandbox), `__init__` throws, so `import FEniCS` fails — which is exactly why the v1.2.1 registration (JuliaRegistries/General) stalls on "I was not able to load the package".

## Fix
Wrap the Python import + constant initialization in a `try`/`catch` that emits a loud `@warn` and lets the module finish loading. Nothing about the working path changes when Python FEniCS *is* present; when it is absent, `using FEniCS` now succeeds with a warning and any actual call into FEniCS errors later (empty `PyNULL` objects), as before.

## Verification
Loaded the branch locally with **no** `fenics`/`ufl` Python packages installed (PyCall pointed at system python3):

```
julia> using FEniCS
┌ Warning: FEniCS.jl loaded but could not import the Python FEniCS/DOLFIN installation, so it is not usable.
│ Calls into FEniCS will error until the `fenics` and `ufl` Python packages (FEniCS 2019.1.0) are installed
│ and importable through PyCall.jl.
└ @ FEniCS .../src/FEniCS.jl:46

julia> isdefined(Main, :FEniCS)   # => true
```

Previously this same `using FEniCS` threw from `__init__`.

Please ignore until reviewed by @ChrisRackauckas.