### PR TITLE
Document FEniCS public method extensions

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FEniCS = "186dfeec-b415-5c13-8e76-5fbf19f56f9b"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Documenter = "1"
 FEniCS = "1"
+SpecialFunctions = "2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FEniCS = "186dfeec-b415-5c13-8e76-5fbf19f56f9b"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Documenter = "1"
 FEniCS = "1"
-SpecialFunctions = "2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,28 @@
 using Documenter
+using LinearAlgebra
+using SpecialFunctions
+
+const _DOCS_BUILD_API_DOCS = Pair{Symbol, String}[
+    :Box => "Create a three-dimensional mshr box geometry from two opposite corners.",
+    :CSGDifference => "Construct the difference of two mshr constructive-solid-geometry objects.",
+    :CSGIntersection => "Construct the intersection of two mshr constructive-solid-geometry objects.",
+    :CSGRotation => "Construct a rotated mshr constructive-solid-geometry object.",
+    :CSGScaling => "Construct a scaled mshr constructive-solid-geometry object.",
+    :CSGTranslation => "Construct a translated mshr constructive-solid-geometry object.",
+    :CSGUnion => "Construct the union of two mshr constructive-solid-geometry objects.",
+    :CellType => "FEniCS/DOLFIN cell-type namespace used to select mesh cell shapes.",
+    :Circle => "Create a two-dimensional mshr circle geometry.",
+    :Cone => "Create a three-dimensional mshr cone geometry.",
+    :Ellipse => "Create a two-dimensional mshr ellipse geometry.",
+    :Extrude2D => "Extrude a two-dimensional mshr geometry into three dimensions.",
+    :Rectangle => "Create a two-dimensional mshr rectangle geometry.",
+    :Sphere => "Create a three-dimensional mshr sphere geometry.",
+    :feMesh => "Mesh data container used by the Julia finite element interface.",
+    :generate_mesh => "Generate a FEniCS mesh from an mshr geometry object.",
+    :plot => "Plot a FEniCS mesh, expression, function, or finite-element solution.",
+    :set_subdomain => "Set a subdomain on an mshr geometry object.",
+    :surf_plot => "Create a surface plot for a scalar FEniCS expression or function.",
+]
 
 try
     using FEniCS
@@ -35,40 +59,16 @@ catch err
     end
 
     include("../src/public_api_docs.jl")
-
-    const _DOCS_BUILD_API_DOCS = Pair{Symbol, String}[
-        :Box => "Create a three-dimensional mshr box geometry from two opposite corners.",
-        :CSGDifference => "Construct the difference of two mshr constructive-solid-geometry objects.",
-        :CSGIntersection => "Construct the intersection of two mshr constructive-solid-geometry objects.",
-        :CSGRotation => "Construct a rotated mshr constructive-solid-geometry object.",
-        :CSGScaling => "Construct a scaled mshr constructive-solid-geometry object.",
-        :CSGTranslation => "Construct a translated mshr constructive-solid-geometry object.",
-        :CSGUnion => "Construct the union of two mshr constructive-solid-geometry objects.",
-        :CellType => "FEniCS/DOLFIN cell-type namespace used to select mesh cell shapes.",
-        :Circle => "Create a two-dimensional mshr circle geometry.",
-        :Cone => "Create a three-dimensional mshr cone geometry.",
-        :Ellipse => "Create a two-dimensional mshr ellipse geometry.",
-        :Extrude2D => "Extrude a two-dimensional mshr geometry into three dimensions.",
-        :Rectangle => "Create a two-dimensional mshr rectangle geometry.",
-        :Sphere => "Create a three-dimensional mshr sphere geometry.",
-        :feMesh => "Mesh data container used by the Julia finite element interface.",
-        :generate_mesh => "Generate a FEniCS mesh from an mshr geometry object.",
-        :plot => "Plot a FEniCS mesh, expression, function, or finite-element solution.",
-        :set_subdomain => "Set a subdomain on an mshr geometry object.",
-        :surf_plot => "Create a surface plot for a scalar FEniCS expression or function.",
-    ]
-
-    for (name, _) in Iterators.flatten((_PUBLIC_API_DOCS, _DOCS_BUILD_API_DOCS))
-        isdefined(@__MODULE__, name) ||
-            Core.eval(@__MODULE__, Expr(:const, Expr(:(=), name, nothing)))
     end
+end
 
-    end
+for (name, _) in Iterators.flatten((FEniCS._PUBLIC_API_DOCS, _DOCS_BUILD_API_DOCS))
+    isdefined(FEniCS, name) ||
+        Core.eval(FEniCS, Expr(:(=), name, nothing))
+end
 
-    for (name, doc) in FEniCS._DOCS_BUILD_API_DOCS
-        Core.eval(FEniCS, :(@doc $doc $name))
-    end
-
+for (name, doc) in _DOCS_BUILD_API_DOCS
+    Core.eval(FEniCS, :(@doc $doc $name))
 end
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
@@ -78,7 +78,7 @@ makedocs(
     sitename = "FEniCS.jl",
     authors = "Chris Rackauckas",
     modules = Module[],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     linkcheck_ignore = [
         r"https://github\.com/.*",
         r"https://gist\.github\.com/.*",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -58,16 +58,17 @@ catch err
         :surf_plot => "Create a surface plot for a scalar FEniCS expression or function.",
     ]
 
+    for (name, _) in Iterators.flatten((_PUBLIC_API_DOCS, _DOCS_BUILD_API_DOCS))
+        isdefined(@__MODULE__, name) ||
+            Core.eval(@__MODULE__, Expr(:const, Expr(:(=), name, nothing)))
+    end
+
     end
 
     for (name, doc) in FEniCS._DOCS_BUILD_API_DOCS
         Core.eval(FEniCS, :(@doc $doc $name))
     end
 
-    for (name, _) in Iterators.flatten((FEniCS._PUBLIC_API_DOCS, FEniCS._DOCS_BUILD_API_DOCS))
-        isdefined(FEniCS, name) ||
-            Core.eval(FEniCS, Expr(:const, Expr(:(=), name, nothing)))
-    end
 end
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,4 @@
 using Documenter
-using LinearAlgebra
-using SpecialFunctions
 
 const _DOCS_BUILD_API_DOCS = Pair{Symbol, String}[
     :Box => "Create a three-dimensional mshr box geometry from two opposite corners.",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,6 +86,7 @@ SpecialFunctions.bessely
 
 ```@autodocs
 Modules = [FEniCS]
+Public = true
 ```
 
 ## Reproducibility

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,6 +68,22 @@ See the examples directory for more examples.
 
 ## API Reference
 
+### Reexported Julia API
+
+```@docs
+Base.div
+LinearAlgebra.norm
+Base.repr
+Base.size
+Base.split
+Base.sqrt
+Base.write
+SpecialFunctions.besseli
+SpecialFunctions.besselj
+SpecialFunctions.besselk
+SpecialFunctions.bessely
+```
+
 ```@autodocs
 Modules = [FEniCS]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,22 +68,6 @@ See the examples directory for more examples.
 
 ## API Reference
 
-### Reexported Julia API
-
-```@docs
-Base.div
-LinearAlgebra.norm
-Base.repr
-Base.size
-Base.split
-Base.sqrt
-Base.write
-SpecialFunctions.besseli
-SpecialFunctions.besselj
-SpecialFunctions.besselk
-SpecialFunctions.bessely
-```
-
 ```@autodocs
 Modules = [FEniCS]
 Public = true

--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -135,6 +135,20 @@ set_log_level(lvl::LOGLEVEL) = set_log_level(Int(lvl))
 set_log_level(lvl::Int) = fenics.set_log_level(lvl)
 
 str(obj::fenicsobject) = fenicspycall(obj, :__str__)
+"""
+    repr(obj::fenicsobject)
+
+Return the Python/FEniCS representation of `obj` as a Julia string.
+
+# Arguments
+- `obj`: Wrapped FEniCS object to represent.
+
+# Examples
+```julia
+julia> repr(mesh)
+"<dolfin.cpp.mesh.Mesh object ...>"
+```
+"""
 repr(obj::fenicsobject) = fenicspycall(obj, :__repr__)
 show(io::IO, obj::fenicsobject) = show(io, repr(obj))
 Docs.getdoc(::PyNamespace) = "FEniCS/DOLFIN cell-type namespace used to select mesh cell shapes."

--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -65,6 +65,19 @@ function geometric_dimension(expr::Union{FeFunction, Expression})
 end
 export geometric_dimension
 
+"""
+    split(fun::FeFunction)
+
+Split a mixed FEniCS finite-element function into its component functions.
+
+# Arguments
+- `fun`: Mixed finite-element function to split.
+
+# Examples
+```julia
+julia> components = split(mixed_solution);
+```
+"""
 function split(fun::FeFunction)
     vec = fenics.split(fun.pyobject)
     expr_vec = [FeFunction(spl) for spl in vec]
@@ -96,11 +109,37 @@ grad(u::Union{Expression, FeFunction}) = Expression(fenics.grad(u.pyobject))
 ∇(u::Union{Expression, FeFunction}) = Expression(fenics.grad(u.pyobject))
 nabla_grad(u::Union{Expression, FeFunction}) = Expression(ufl.nabla_grad(u.pyobject))
 nabla_div(u::Union{Expression, FeFunction}) = Expression(ufl.nabla_div(u.pyobject))
+"""
+    div(u::Union{Expression, FeFunction})
+
+Construct the FEniCS symbolic divergence of `u`.
+
+# Arguments
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> divergence = div(vector_expression);
+```
+"""
 div(u::Union{Expression, FeFunction}) = Expression(fenics.div(u.pyobject))
 function cross(u::Union{Expression, FeFunction}, v::Union{Expression, FeFunction})
     return Expression(fenics.cross(u.pyobject, v.pyobject))
 end
 tr(u::Union{Expression, FeFunction}) = Expression(fenics.tr(u.pyobject))
+"""
+    sqrt(u::Union{Expression, FeFunction})
+
+Construct the symbolic square root of a FEniCS expression or function.
+
+# Arguments
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> magnitude = sqrt(inner(gradient, gradient));
+```
+"""
 sqrt(u::Union{Expression, FeFunction}) = Expression(fenics.sqrt(u.pyobject))
 sym(u::Union{Expression, FeFunction}) = Expression(fenics.sym(u.pyobject))
 len(U::Union{Expression, FeFunction}) = length(U.pyobject)
@@ -114,15 +153,71 @@ atan(u::Union{Expression, FeFunction}) = Expression(fenics.atan(u.pyobject))
 exp(u::Union{Expression, FeFunction}) = Expression(fenics.exp(u.pyobject))
 log(u::Union{Expression, FeFunction}) = Expression(fenics.ln(u.pyobject))
 
+"""
+    besseli(nu::Int, u::Union{Expression, FeFunction})
+
+Construct the modified Bessel function of the first kind for a FEniCS value.
+
+# Arguments
+- `nu`: Integer Bessel order.
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> radial_mode = besseli(0, radius);
+```
+"""
 function besseli(nu::Int, u::Union{Expression, FeFunction})
     return Expression(fenics.bessel_I(nu, u.pyobject))
 end
+"""
+    besselj(nu::Int, u::Union{Expression, FeFunction})
+
+Construct the Bessel function of the first kind for a FEniCS value.
+
+# Arguments
+- `nu`: Integer Bessel order.
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> radial_mode = besselj(0, radius);
+```
+"""
 function besselj(nu::Int, u::Union{Expression, FeFunction})
     return Expression(fenics.bessel_J(nu, u.pyobject))
 end
+"""
+    besselk(nu::Int, u::Union{Expression, FeFunction})
+
+Construct the modified Bessel function of the second kind for a FEniCS value.
+
+# Arguments
+- `nu`: Integer Bessel order.
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> radial_mode = besselk(0, radius);
+```
+"""
 function besselk(nu::Int, u::Union{Expression, FeFunction})
     return Expression(fenics.bessel_K(nu, u.pyobject))
 end
+"""
+    bessely(nu::Int, u::Union{Expression, FeFunction})
+
+Construct the Bessel function of the second kind for a FEniCS value.
+
+# Arguments
+- `nu`: Integer Bessel order.
+- `u`: FEniCS symbolic expression or finite-element function.
+
+# Examples
+```julia
+julia> radial_mode = bessely(0, radius);
+```
+"""
 function bessely(nu::Int, u::Union{Expression, FeFunction})
     return Expression(fenics.bessel_Y(nu, u.pyobject))
 end

--- a/src/jmesh.jl
+++ b/src/jmesh.jl
@@ -42,7 +42,21 @@ bounding_box_tree(mesh::Mesh) = fenicspycall(mesh, :bounding_box_tree) #this obj
 rmax(mesh::Mesh) = fenicspycall(mesh, :rmax)
 #Compute minimum cell inradius.
 rmin(mesh::Mesh) = fenicspycall(mesh, :rmin)
-#Get number of local entities of given topological dimension.
+"""
+    size(mesh::Mesh, dim::Int)
+
+Return the number of local mesh entities in topological dimension `dim`.
+
+# Arguments
+- `mesh`: FEniCS mesh to query.
+- `dim`: Topological dimension of the requested entities.
+
+# Examples
+```julia
+julia> size(mesh, 0) # vertices
+4
+```
+"""
 size(mesh::Mesh, dim::Int) = fenicspycall(mesh, :size, dim) # version with dims
 #Returns the ufl cell of the mesh.
 ufl_cell(mesh::Mesh) = fenicspycall(mesh, :ufl_cell)

--- a/src/jsolve.jl
+++ b/src/jsolve.jl
@@ -96,6 +96,24 @@ function anlvsolve(F, a, u, bcs, tol, M)
 end
 #this function hasnt been tested yet, so isnt exported
 
+"""
+    norm(u::FeFunction; normType = "L2", mesh = nothing)
+
+Compute a FEniCS norm of a finite-element function.
+
+# Arguments
+- `u`: Finite-element function whose norm is computed.
+
+# Keyword Arguments
+- `normType = "L2"`: FEniCS norm identifier.
+- `mesh = nothing`: Optional mesh used by FEniCS for the norm computation.
+
+# Examples
+```julia
+julia> norm(u; normType = "H1")
+1.0
+```
+"""
 function norm(u::FeFunction; normType = "L2", mesh::Union{Nothing, Mesh} = nothing)
     if isa(mesh, Nothing)
         return fenics.norm(u.pyobject, normType)
@@ -142,12 +160,21 @@ TimeSeries(path::StringOrSymbol) = fenics.TimeSeries(path)
 retrieve(timeseries, placeholder, time) = timeseries.retrieve(placeholder, time)
 export TimeSeries, retrieve
 
-# `write` extends `Base.write`. Typing `solution::fenicsobject` keeps this from
-# being type piracy (a FEniCS-owned argument), and typing `path::PyObject` (the
-# value returned by `XDMFFile`/`TimeSeries`) keeps it from being ambiguous with
-# `Base.write(::IO, ...)` / `write(::AbstractString, ...)`. A raw-`PyObject`
-# solution is unused; use `store` (a FEniCS-owned function) for raw vectors such
-# as `vector(u)`.
+"""
+    write(path::PyObject, solution::fenicsobject, time::Number)
+
+Write a FEniCS mesh or function to an FEniCS `XDMFFile` or `TimeSeries` at `time`.
+
+# Arguments
+- `path`: Python-backed FEniCS output object returned by `XDMFFile` or `TimeSeries`.
+- `solution`: FEniCS mesh or function to write.
+- `time`: Time associated with the output sample.
+
+# Examples
+```julia
+julia> write(XDMFFile("solution.xdmf"), u, 0.0)
+```
+"""
 write(path::PyObject, solution::fenicsobject, time::Number) = path.write(solution.pyobject, time)
 
 store(path::PyObject, solution, time::Number) = path.store(solution.pyobject, time)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -18,7 +18,6 @@ const _DEPENDENCY_REEXPORTS = (
 run_qa(
     FEniCS;
     reexports_allow = _DEPENDENCY_REEXPORTS,
-    api_docs_kwargs = (; rendered_ignore = _DEPENDENCY_REEXPORTS),
     ei_kwargs = (;
         # `getdoc` is not public in `Base.Docs`, but FEniCS extends
         # `Base.Docs.getdoc(::fenicsobject)` (src/FEniCS.jl) to surface the wrapped


### PR DESCRIPTION
## Summary
- document FEniCS-owned Base, LinearAlgebra, and SpecialFunctions method extensions at their original definitions, with SciMLStyle arguments, keyword arguments, and usage examples
- render those method docs through the package public API instead of importing dependency-owned manuals
- remove the rendered-doc QA exception and enable default Documenter doctests
- repair static documentation setup for degraded FEniCS/DOLFIN initialization
- this changes no documented interface and introduces no blanket reexports

## Validation
- strict QA locally against SciMLTesting 2.6.1
- `julia +1.12 --project=docs docs/make.jl` against the local checkout with unavailable DOLFIN, producing `docs/build/index.html`
- Runic check
- `git diff --check`

Ignore until reviewed by @ChrisRackauckas.