### PR TITLE
Bump FEniCS to 1.3.1 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FEniCS"
 uuid = "186dfeec-b415-5c13-8e76-5fbf19f56f9b"
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
tree recorded in the General registry for their current version, but the version was never
bumped — so the changes cannot be released.

| package | from | to | kind | why |
|---|---|---|---|---|
| `FEniCS` | 1.3.0 | **1.3.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

### How the versions were chosen

Patch by default. A package was promoted to a **minor** bump only where it gained public API
or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
in the patch position regardless of what they added.

No package in this PR needs a major bump: comparing the exported/`@public` name sets between
each package's released commit and master, **no name that the package itself defines was
removed**. The removals that do appear are blanket reexports of names owned by other packages
(e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
SciML does not treat as documented public API.

Registration follows once this merges.

---

Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
